### PR TITLE
Updated CustomFields/MutableCustomFields Protocols

### DIFF
--- a/Example/Cartfile.private
+++ b/Example/Cartfile.private
@@ -1,1 +1,1 @@
-github "venmo/QuizTrain" ~> 1.1.0
+github "venmo/QuizTrain" ~> 1.1.1

--- a/Example/Cartfile.resolved
+++ b/Example/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "venmo/QuizTrain" "v1.1.0"
+github "venmo/QuizTrain" "v1.1.1"

--- a/QuizTrain/Info.plist
+++ b/QuizTrain/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/QuizTrain/Misc/Containment/Protocols/CustomFields.swift
+++ b/QuizTrain/Misc/Containment/Protocols/CustomFields.swift
@@ -1,13 +1,6 @@
 /*
  Provides read-only CustomField support.
  */
-protocol CustomFields {
+public protocol CustomFields {
     var customFields: JSONDictionary { get }
-    var customFieldsContainer: CustomFieldsContainer { get }
-}
-
-extension CustomFields {
-    public var customFields: JSONDictionary {
-        return self.customFieldsContainer.customFields
-    }
 }

--- a/QuizTrain/Misc/Containment/Protocols/MutableCustomFields.swift
+++ b/QuizTrain/Misc/Containment/Protocols/MutableCustomFields.swift
@@ -1,18 +1,6 @@
 /*
  Provides read-write CustomField support.
  */
-protocol MutableCustomFields: CustomFields {
+public protocol MutableCustomFields: CustomFields {
     var customFields: JSONDictionary { get set }
-    var customFieldsContainer: CustomFieldsContainer { get set }
-}
-
-extension MutableCustomFields {
-    public var customFields: JSONDictionary {
-        get {
-            return self.customFieldsContainer.customFields
-        }
-        set {
-            customFieldsContainer.customFields = newValue
-        }
-    }
 }

--- a/QuizTrain/Models/Case.swift
+++ b/QuizTrain/Models/Case.swift
@@ -16,6 +16,10 @@ public struct Case: Identifiable, MutableCustomFields, Equatable {
     public let updatedBy: User.Id
     public let updatedOn: Date
     var customFieldsContainer: CustomFieldsContainer
+    public var customFields: JSONDictionary {
+        get { return self.customFieldsContainer.customFields }
+        set { customFieldsContainer.customFields = newValue }
+    }
 }
 
 // MARK: - Foward Relationships (ObjectAPI)

--- a/QuizTrain/Models/Result.swift
+++ b/QuizTrain/Models/Result.swift
@@ -11,6 +11,9 @@ public struct Result: CustomFields, Identifiable, Equatable {
     public let testId: Test.Id
     public let version: String?
     let customFieldsContainer: CustomFieldsContainer
+    public var customFields: JSONDictionary {
+        return self.customFieldsContainer.customFields
+    }
 }
 
 // MARK: - Foward Relationships (ObjectAPI)

--- a/QuizTrain/Models/Test.swift
+++ b/QuizTrain/Models/Test.swift
@@ -14,6 +14,9 @@ public struct Test: CustomFields, Identifiable, Equatable {
     public let title: String
     public let typeId: CaseType.Id
     let customFieldsContainer: CustomFieldsContainer
+    public var customFields: JSONDictionary {
+        return self.customFieldsContainer.customFields
+    }
 }
 
 // MARK: - Foward Relationships (ObjectAPI)

--- a/QuizTrain/Network/Models/Add/NewCase.swift
+++ b/QuizTrain/Network/Models/Add/NewCase.swift
@@ -10,6 +10,10 @@ public struct NewCase: MutableCustomFields, Equatable {
     public var title: String
     public var typeId: CaseType.Id?
     var customFieldsContainer = CustomFieldsContainer.empty()
+    public var customFields: JSONDictionary {
+        get { return self.customFieldsContainer.customFields }
+        set { customFieldsContainer.customFields = newValue }
+    }
 
     // MARK: Init
 

--- a/QuizTrain/Network/Models/Add/NewCaseResults.Result.swift
+++ b/QuizTrain/Network/Models/Add/NewCaseResults.Result.swift
@@ -12,6 +12,10 @@ extension NewCaseResults {
         public var statusId: Status.Id?
         public var version: String?
         var customFieldsContainer = CustomFieldsContainer.empty()
+        public var customFields: JSONDictionary {
+            get { return self.customFieldsContainer.customFields }
+            set { customFieldsContainer.customFields = newValue }
+        }
 
         // MARK: Init
 

--- a/QuizTrain/Network/Models/Add/NewResult.swift
+++ b/QuizTrain/Network/Models/Add/NewResult.swift
@@ -12,6 +12,10 @@ public struct NewResult: MutableCustomFields, Equatable {
     public var statusId: Status.Id?
     public var version: String?
     var customFieldsContainer = CustomFieldsContainer.empty()
+    public var customFields: JSONDictionary {
+        get { return self.customFieldsContainer.customFields }
+        set { customFieldsContainer.customFields = newValue }
+    }
 
     // MARK: Init
 

--- a/QuizTrain/Network/Models/Add/NewTestResults.Result.swift
+++ b/QuizTrain/Network/Models/Add/NewTestResults.Result.swift
@@ -12,6 +12,10 @@ extension NewTestResults {
         public var testId: Test.Id
         public var version: String?
         var customFieldsContainer = CustomFieldsContainer.empty()
+        public var customFields: JSONDictionary {
+            get { return self.customFieldsContainer.customFields }
+            set { customFieldsContainer.customFields = newValue }
+        }
 
         // MARK: Init
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ QuizTrain is open source software released under the MIT License. See the [LICEN
 
 [Carthage](https://github.com/Carthage/Carthage) is the recommended way to install QuizTrain. Add the following to your `Cartfile` or `Cartfile.private` file:
 
-    github "venmo/QuizTrain" ~> 1.1.0
+    github "venmo/QuizTrain" ~> 1.1.1
 
 See [Adding frameworks to an application](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for further instructions. Once complete `import QuizTrain` in any Swift files you wish to use QuizTrain in.
 


### PR DESCRIPTION
- Publicly exposed customFields from protocols for Swift 4.2.
- Migrated models accordingly.
- Set version to 1.1.1.