### PR TITLE
Bump version from 2.0.0 to 2.1.0.

### DIFF
--- a/QuizTrain.podspec
+++ b/QuizTrain.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "QuizTrain"
-  spec.version      = "2.0.0"
+  spec.version      = "2.1.0"
   spec.summary      = "QuizTrain is a framework created at Venmo allowing you to interact with TestRail's API using Swift."
   spec.homepage     = "https://github.com/venmo/QuizTrain"
   spec.license      = "MIT"

--- a/QuizTrain/Info.plist
+++ b/QuizTrain/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.2</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/README.md
+++ b/README.md
@@ -10,11 +10,21 @@ QuizTrain is open source software released under the MIT License. See the [LICEN
 
 ## Installation
 
-[Carthage](https://github.com/Carthage/Carthage) is the recommended way to install QuizTrain. Add the following to your `Cartfile` or `Cartfile.private` file:
+### Carthage
 
-    github "venmo/QuizTrain" ~> 2.0.0
+After upgrading to the latest version of [Carthage](https://github.com/Carthage/Carthage) add the following to your `Cartfile` or `Cartfile.private` file:
+
+    github "venmo/QuizTrain" ~> 2.1.0
 
 See [Adding frameworks to an application](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for further instructions. Once complete `import QuizTrain` in any Swift files you wish to use QuizTrain in.
+
+### Cocoapods
+
+In your [`Podfile`](https://guides.cocoapods.org/using/the-podfile.html) add the following line to your target and save the file:
+
+    pod 'QuizTrain', '~> 2.1.0'
+
+Run `pod install`, open your project `.xcworkspace` file, and you should now be able to `import QuizTrain` into your code.
 
 ## Usage
 


### PR DESCRIPTION
- Increased version from 2.0.0 to 2.1.0 for Cocoapods support.
- Updated README installation instructions.
- Updated QuizTrain.podspec spec.version to 2.1.0.