### PR TITLE
Repair Carthage usability by removing erroneous submodule reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Carthage/Checkouts/QuizTrain"]
-	path = Example/Carthage/Checkouts/QuizTrain
-	url = ssh://git@github.com/venmo/QuizTrain.git


### PR DESCRIPTION
In order to be able to use Carthage to manage QuizTrain as a dependency, it can't have any missing or broken submodules references in the `.gitmodules` file. As there are no submodules for QuizTrain as it currently stands, we removed the entire file to get it to work.

h/t to https://davidwalsh.name/git-remove-submodule for the instructions for proper submodule cleanup