### PR TITLE
Added URL Path and Skip SSL init params

### DIFF
--- a/QuizTrain/Network/ObjectAPI.swift
+++ b/QuizTrain/Network/ObjectAPI.swift
@@ -59,8 +59,8 @@ final public class ObjectAPI {
         self.retryQueue = DispatchQueue(label: "ObjectAPI.retryQueue", qos: retryQueueQoS)
     }
 
-    public convenience init(username: String, secret: String, hostname: String, port: Int = 443, scheme: String = "https", retryQueueQoS: DispatchQoS = .`default`) {
-        let api = API(username: username, secret: secret, hostname: hostname, port: port, scheme: scheme)
+    public convenience init(username: String, secret: String, hostname: String, port: Int = 443, scheme: String = "https", retryQueueQoS: DispatchQoS = .`default`, path: String = "/index.php", skipSSL: Bool = false) {
+        let api = API(username: username, secret: secret, hostname: hostname, port: port, scheme: scheme, path: path, skipSSL: skipSSL)
         self.init(api: api, retryQueueQoS: retryQueueQoS)
     }
 


### PR DESCRIPTION
- Resolve issue #20 and #21

Adding 'path' as optional params allows for QuizTrain to be used in more customized TestRail configuration environments

Adding ability to skip SSL certification validation allows users to add QuizTrain into in-house projects protected by internal network. 